### PR TITLE
update stable helm repo link, remove deprecated K8 API

### DIFF
--- a/charts/netflix-conductor/templates/deployment-conductor-server.yaml
+++ b/charts/netflix-conductor/templates/deployment-conductor-server.yaml
@@ -1,8 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "apps/v1" }}
 apiVersion: apps/v1
-{{- else }}
-apiVersion: apps/v1beta1
-{{- end }}
 kind: Deployment
 metadata:
   name: {{ include "netflix-conductor.name" . }}-server

--- a/charts/netflix-conductor/templates/deployment-conductor-ui.yaml
+++ b/charts/netflix-conductor/templates/deployment-conductor-ui.yaml
@@ -1,8 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "apps/v1" }}
 apiVersion: apps/v1
-{{- else }}
-apiVersion: apps/v1beta1
-{{- end }}
 kind: Deployment
 metadata:
   name: {{ include "netflix-conductor.name" . }}-ui


### PR DESCRIPTION
We don't have pre `1.9` K8 cluster, and I'd say we don't wanna support that.
Removing deprecated k8 API completely. See https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ 

Our K8 ver:
v1.15.12-eks-31566f: streamotion nonprod1, streamotion nonprod2, streamotion prod-1, streamotion prod-2
v1.13.12-eks-3e38fc: gitops
v1.15.11                      : on prem(new) dev, staging, prod
v1.13.5                       : on prem staging, prod
(there'r more but should be around these ver)

(We clean this up then add ServiceAccount object for OIDC.)